### PR TITLE
Setup Dependency Injection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-kapt'
     id 'androidx.navigation.safeargs.kotlin'
+    id 'com.google.dagger.hilt.android'
+
 }
 
 android {
@@ -48,6 +50,9 @@ android {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
+    }
+    kapt {
+        correctErrorTypes = true
     }
 }
 
@@ -110,6 +115,15 @@ dependencies {
     api 'com.google.dagger:dagger-android:2.35.1'
     api 'com.google.dagger:dagger-android-support:2.28.1'
     kapt 'com.google.dagger:dagger-android-processor:2.23.2'
+
+    // Activity KTX for viewModels()
+    implementation 'androidx.activity:activity-ktx:1.6.1'
+
+    // Dagger - Hilt
+    implementation "com.google.dagger:hilt-android:2.44"
+    kapt "com.google.dagger:hilt-android-compiler:2.44"
+
+    kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     // Easy Permissions
     implementation 'pub.devrel:easypermissions:3.0.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
+        android:name=".BaseApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/runningtracker/BaseApplication.kt
+++ b/app/src/main/java/com/example/runningtracker/BaseApplication.kt
@@ -1,0 +1,9 @@
+package com.example.runningtracker
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class BaseApplication : Application( ) {
+
+}

--- a/app/src/main/java/com/example/runningtracker/MainActivity.kt
+++ b/app/src/main/java/com/example/runningtracker/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.runningtracker
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,9 +11,17 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.runningtracker.db.RunDAO
 import com.example.runningtracker.ui.theme.RunningTrackerTheme
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var runDao: RunDAO
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -26,6 +35,7 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+        Log.d("runDao", "RUNDAO: ${runDao.hashCode()}")
     }
 }
 

--- a/app/src/main/java/com/example/runningtracker/db/Converters.kt
+++ b/app/src/main/java/com/example/runningtracker/db/Converters.kt
@@ -2,17 +2,17 @@ package com.example.runningtracker.db
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import androidx.room.TypeConverters
+import androidx.room.TypeConverter
 import java.io.ByteArrayOutputStream
 
 class Converters {
 
-    @TypeConverters
+    @TypeConverter
     fun toBitmap(bytes: ByteArray): Bitmap {
         return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
     }
 
-    @TypeConverters
+    @TypeConverter
     fun fromBitmap(bmp: Bitmap): ByteArray {
         val outputStream = ByteArrayOutputStream()
         bmp.compress(Bitmap.CompressFormat.PNG, 100, outputStream)

--- a/app/src/main/java/com/example/runningtracker/di/AppModule.kt
+++ b/app/src/main/java/com/example/runningtracker/di/AppModule.kt
@@ -1,0 +1,31 @@
+package com.example.runningtracker.di
+
+import android.content.Context
+import androidx.room.Room
+import com.example.runningtracker.db.RunningDatabase
+import com.example.runningtracker.other.Constants.RUNNING_DATABASE_NAME
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Singleton
+    @Provides
+    fun provideRunningDatabase(
+        @ApplicationContext app: Context
+    ) = Room.databaseBuilder(
+        app,
+        RunningDatabase::class.java,
+        RUNNING_DATABASE_NAME
+    ).build()
+
+    @Singleton
+    @Provides
+    fun provideRunDao(db: RunningDatabase) = db.getRunDao()
+}

--- a/app/src/main/java/com/example/runningtracker/other/Constants.kt
+++ b/app/src/main/java/com/example/runningtracker/other/Constants.kt
@@ -1,0 +1,6 @@
+package com.example.runningtracker.other
+
+object Constants {
+
+    const val RUNNING_DATABASE_NAME = "running_db"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version")
+        classpath("com.google.dagger:hilt-android-gradle-plugin:2.28-alpha")
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
@@ -19,6 +20,7 @@ plugins {
     id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'androidx.navigation.safeargs.kotlin' version '2.4.1' apply false
+    id 'com.google.dagger.hilt.android' version "2.44" apply false
 }
 task clean(type: Delete) {
     delete rootProject.buildDir


### PR DESCRIPTION
- Apply Dagger-Hilt dependencies in Gradle.
- Create ```BaseApplication``` class and add annotation ```@HiltAndroidApp```
- Create ```AppModule``` object and annotate ```@Module``` and ```@InstallIn(SingletonComponent::class)``` to tell dagger this module should be run as the app run and should be killed when the app is killed.
  - Annotate ```@Singleton``` for ```provideRunningDatabase``` function to tell dagger there is only one instance of the database in this app's lifecycle.
  - Create and provide dependencies in  ```AppModule``` object and inject them into the activity.
- Test the injection in logcat.